### PR TITLE
Custom resolvers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # hakrevdns
+
 Small, fast, simple tool for performing reverse DNS lookups en masse.
 
 You feed it IP addresses, it returns hostnames.
 
 This can be a useful way of finding domains and subdomains belonging to a company from their IP addresses.
 
-# Installation
-```
+## Installation
+
+```sh
 go get github.com/hakluke/hakrevdns
 ```
 
-# Usage
+## Usage
 Pipe a list of IP addresses into the tool, for example:
 
-```
+```sh
 hakluke~$ prips 173.0.84.0/24 | hakrevdns 
 173.0.84.110	he.paypal.com.
 173.0.84.109	twofasapi.paypal.com.
@@ -29,4 +31,27 @@ hakluke~$ prips 173.0.84.0/24 | hakrevdns
 173.0.84.2	active-www.paypal.com.
 173.0.84.4	securepayments.paypal.com.
 ...
+```
+
+### Parameters
+
+```sh
+hakluke~$ hakrevdns -h
+Usage:
+  hakrevdns [OPTIONS]
+
+Application Options:
+  -r, --resolver=          IP of the DNS resolver to use for lookups
+  -P, --protocol=[tcp|udp] Protocol to use for lookups (default: udp)
+  -p, --port=              Port to bother the specified DNS resolver on (default: 53)
+
+Help Options:
+  -h, --help               Show this help message
+```
+
+If you want to use a resolver not specified by you OS, say: 1.1.1.1, try this:
+
+```sh
+hakluke~$ echo "173.0.84.110" | hakrevdns -r 1.1.1.1
+173.0.84.110    he.paypal.com.
 ```

--- a/main.go
+++ b/main.go
@@ -20,26 +20,21 @@ var opts struct {
 func worker(ip string, wg *sync.WaitGroup) {
 	defer wg.Done()
 
+	var r *net.Resolver
+
 	if opts.ResolverIP != "" {
-		r := &net.Resolver{
+		r = &net.Resolver{
 			PreferGo: true,
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 				d := net.Dialer{}
 				return d.DialContext(ctx, opts.Protocol, fmt.Sprintf("%s:%d", opts.ResolverIP, opts.Port))
 			},
 		}
+	}
 
-		addr, err := r.LookupAddr(context.Background(), ip)
-		if err == nil {
-			fmt.Printf("%s\t%s\n", ip, addr[0])
-		} else {
-			fmt.Println(err)
-		}
-	} else {
-		addr, err := net.LookupAddr(ip)
-		if err == nil {
-			fmt.Printf("%s\t%s\n", ip, addr[0])
-		}
+	addr, err := r.LookupAddr(context.Background(), ip)
+	if err == nil {
+		fmt.Printf("%s\t%s\n", ip, addr[0])
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,24 +1,54 @@
 package main
 
 import (
+	"bufio"
+	"context"
 	"fmt"
 	"net"
-	"sync"
-	"bufio"
 	"os"
+	"sync"
+
+	flags "github.com/jessevdk/go-flags"
 )
 
+var opts struct {
+	ResolverIP string `short:"r" long:"resolver" description:"IP of the DNS resolver to use for lookups"`
+	Protocol   string `short:"P" long:"protocol" choice:"tcp" choice:"udp" default:"udp" description:"Protocol to use for lookups"`
+	Port       uint16 `short:"p" long:"port" default:"53" description:"Port to bother the specified DNS resolver on"`
+}
+
 func worker(ip string, wg *sync.WaitGroup) {
-	addr, err := net.LookupAddr(ip)	
-	if err != nil{
-		wg.Done()
-		return
+	defer wg.Done()
+
+	if opts.ResolverIP != "" {
+		r := &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{}
+				return d.DialContext(ctx, opts.Protocol, fmt.Sprintf("%s:%d", opts.ResolverIP, opts.Port))
+			},
+		}
+
+		addr, err := r.LookupAddr(context.Background(), ip)
+		if err == nil {
+			fmt.Printf("%s\t%s\n", ip, addr[0])
+		} else {
+			fmt.Println(err)
+		}
+	} else {
+		addr, err := net.LookupAddr(ip)
+		if err == nil {
+			fmt.Printf("%s\t%s\n", ip, addr[0])
+		}
 	}
-	fmt.Println(ip + "\t" + addr[0])
-	wg.Done()
 }
 
 func main() {
+	_, err := flags.ParseArgs(&opts, os.Args)
+	if err != nil {
+		os.Exit(1)
+	}
+
 	scanner := bufio.NewScanner(os.Stdin)
 	var wg sync.WaitGroup
 	for scanner.Scan() {


### PR DESCRIPTION
fixes #2 

There are some caveats though. It doesn't work on all platforms (i.e. Windows), and silently falls back to the cgo netdns resolver (read system set resolver), which doesn't care about fancy DialContexts.
