### PR TITLE
Defer wg.Done() and continue instead of return

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 }
 
 func doWork(work chan string, wg *sync.WaitGroup) {
+    defer wg.Done()
     var r *net.Resolver
 
     if opts.ResolverIP != "" {
@@ -60,12 +61,11 @@ func doWork(work chan string, wg *sync.WaitGroup) {
     for ip := range work {
         addr, err := r.LookupAddr(context.Background(), ip)
         if err != nil {
-                return
+                continue
         }
 
         for _, a := range addr {
                 fmt.Println(ip, "\t",a)
         }
     }
-    wg.Done()
 }


### PR DESCRIPTION
With wg.Done() at the bottom of doWork function and loop returning on error the program would freeze if there was an error. So I've added defer to wg.Done()  and moved it to the top. I also think it would be better to continue in the loop instead of return on error, this way program will keep checking other IPs from the list.