### PR TITLE
Implemented -f flag to accept a list of resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ hakluke~$ echo "173.0.84.110" | hakrevdns -r 1.1.1.1
 173.0.84.110    he.paypal.com.
 ```
 
+If you want to use a list of resolvers, try this:
+
+```sh
+hakluke~$ echo "173.0.84.110" | hakrevdns -f resolvers.txt
+173.0.84.110    he.paypal.com.
+```
+
+
 If you wish to obtain only a list of domains without IP addresses, you can use `-d`:
 
 ```sh
@@ -73,3 +81,4 @@ $ echo "173.0.84.110" | hakrevdns -d | httprobe
 - [hakluke](https://twitter.com/hakluke) wrote the tool
 - [alphakilo](https://github.com/Alphakilo/) added the option to use custom resolvers
 - [SaveBreach](https://twitter.com/SaveBreach/) added the -d flag and cleaned up the code
+- [e1abrador](https://github.com/e1abrador) added -f flag to use a list of resolvers.

--- a/main.go
+++ b/main.go
@@ -3,75 +3,103 @@ package main
 import (
     "bufio"
     "context"
-    flags "github.com/jessevdk/go-flags"
     "fmt"
     "net"
-    "sync"
-    "strings"
     "os"
+    "strings"
+    "sync"
+
+    flags "github.com/jessevdk/go-flags"
 )
 
 var opts struct {
-        Threads int `short:"t" long:"threads" default:"8" description:"How many threads should be used"`
-        ResolverIP string `short:"r" long:"resolver" description:"IP of the DNS resolver to use for lookups"`
-        Protocol   string `short:"P" long:"protocol" choice:"tcp" choice:"udp" default:"udp" description:"Protocol to use for lookups"`
-        Port       uint16 `short:"p" long:"port" default:"53" description:"Port to bother the specified DNS resolver on"`
-	Domain     bool   `short:"d" long:"domain" description:"Output only domains"`
+    Threads      int      `short:"t" long:"threads" default:"8" description:"How many threads should be used"`
+    ResolverIP   string   `short:"r" long:"resolver" description:"IP of the DNS resolver to use for lookups"`
+    Resolvers    []string `short:"R" long:"resolvers" description:"List of DNS resolver IPs to use for lookups, separated by comma"`
+    ResolverFile string   `short:"f" long:"resolver-file" description:"File containing list of DNS resolver IPs"`
+    Protocol     string   `short:"P" long:"protocol" choice:"tcp" choice:"udp" default:"udp" description:"Protocol to use for lookups"`
+    Port         uint16   `short:"p" long:"port" default:"53" description:"Port to bother the specified DNS resolver on"`
+    Domain       bool     `short:"d" long:"domain" description:"Output only domains"`
 }
 
 func main() {
-        _, err := flags.ParseArgs(&opts, os.Args)
-        if err != nil{
-            os.Exit(1)
+    _, err := flags.ParseArgs(&opts, os.Args)
+    if err != nil {
+        os.Exit(1)
+    }
+
+    numWorkers := opts.Threads
+
+    work := make(chan string)
+    go func() {
+        s := bufio.NewScanner(os.Stdin)
+        for s.Scan() {
+            work <- s.Text()
         }
+        close(work)
+    }()
 
-        // default of 8 threads
-        numWorkers := opts.Threads
+    wg := &sync.WaitGroup{}
 
-        work := make(chan string)
-        go func() {
-            s := bufio.NewScanner(os.Stdin)
-            for s.Scan() {
-                work <- s.Text()
-            }
-            close(work)
-        }()
-
-        wg := &sync.WaitGroup{}
-
-        for i := 0; i < numWorkers; i++ {
-            wg.Add(1)
-            go doWork(work, wg)
-        }
-        wg.Wait()
+    for i := 0; i < numWorkers; i++ {
+        wg.Add(1)
+        go doWork(work, wg)
+    }
+    wg.Wait()
 }
 
 func doWork(work chan string, wg *sync.WaitGroup) {
     defer wg.Done()
-    var r *net.Resolver
 
-    if opts.ResolverIP != "" {
-            r = &net.Resolver{
-                    PreferGo: true,
-                    Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-                            d := net.Dialer{}
-                            return d.DialContext(ctx, opts.Protocol, fmt.Sprintf("%s:%d", opts.ResolverIP, opts.Port))
-                    },
-            }
+    resolvers, err := getResolvers()
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "Error reading resolvers:", err)
+        return
     }
 
     for ip := range work {
-        addr, err := r.LookupAddr(context.Background(), ip)
+        var addr []string
+        for _, resolverIP := range resolvers {
+            r := &net.Resolver{
+                PreferGo: true,
+                Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+                    d := net.Dialer{}
+                    return d.DialContext(ctx, opts.Protocol, fmt.Sprintf("%s:%d", resolverIP, opts.Port))
+                },
+            }
+
+            addr, err = r.LookupAddr(context.Background(), ip)
+            if err == nil {
+                break // Exit the loop if a successful lookup is achieved
+            }
+        }
+
         if err != nil {
-                continue
+            fmt.Fprintln(os.Stderr, "Lookup failed for IP:", ip, "Error:", err)
+            continue
         }
 
         for _, a := range addr {
-		if opts.Domain {
-			fmt.Println(strings.TrimRight(a, "."))
-		} else {
-                	fmt.Println(ip, "\t",a)
-		}
+            if opts.Domain {
+                fmt.Println(strings.TrimRight(a, "."))
+            } else {
+                fmt.Println(ip, "\t", a)
+            }
         }
     }
+}
+
+func getResolvers() ([]string, error) {
+    if opts.ResolverFile != "" {
+        file, err := os.ReadFile(opts.ResolverFile)
+        if err != nil {
+            return nil, err
+        }
+        return strings.Split(strings.TrimSpace(string(file)), "\n"), nil
+    } else if len(opts.Resolvers) > 0 {
+        return opts.Resolvers, nil
+    } else if opts.ResolverIP != "" {
+        return []string{opts.ResolverIP}, nil
+    }
+    return []string{}, nil // or return a default resolver if you wish
 }


### PR DESCRIPTION
Hello,

I added to the script the -f flag that will accept a list of resolvers. Basically, it goes through the list of resolvers in the order they are provided. For each IP address, it tries the first resolver; if that fails, it tries the next one, and so on, until it either finds a successful response or exhausts the list of resolvers.