### PR TITLE
Added 2 more Flags to enhance the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,17 @@ hakluke~$ prips 173.0.84.0/24 | hakrevdns
 ```sh
 hakluke~$ hakrevdns -h
 Usage:
-  hakrevdns [OPTIONS]
+  main [OPTIONS]
 
 Application Options:
-  -t, --threads=           Number of threads (too many may get you banned, too few will be slow)
+  -t, --threads=           How many threads should be used (default: 8)
   -r, --resolver=          IP of the DNS resolver to use for lookups
+  -R, --resolvers-file=    File containing list of DNS resolvers to use for lookups      
+  -U, --use-default        Use default resolvers for lookups
   -P, --protocol=[tcp|udp] Protocol to use for lookups (default: udp)
-  -p, --port=              Port to bother the specified DNS resolver on (default: 53)
+  -p, --port=              Port to bother the specified DNS resolver on (default: 53)    
   -d, --domain             Output only domains
+  -h, --help               Show help message
 
 Help Options:
   -h, --help               Show this help message

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Help Options:
   -h, --help               Show this help message
 ```
 
+### New Flags
+    -U, --use-default: 
+    When specified, this flag tells the program to use a predefined list of default DNS resolvers for lookups. This is useful for ensuring consistent DNS resolution across various environments, especially if no custom resolvers are provided.
+    
+    -R, --resolvers-file: 
+    This flag allows you to specify a file containing a list of custom DNS resolvers. Each line in the file should contain a single resolver IP address. If both -R and -r are provided, the resolver specified by -r is added to the list of resolvers from the file.
+
 If you want to use a resolver not specified by your OS, say: 1.1.1.1, try this:
 
 ```sh

--- a/main.go
+++ b/main.go
@@ -1,77 +1,127 @@
 package main
 
 import (
-    "bufio"
-    "context"
-    flags "github.com/jessevdk/go-flags"
-    "fmt"
-    "net"
-    "sync"
-    "strings"
-    "os"
+	"bufio"
+	"context"
+	"fmt"
+	flags "github.com/jessevdk/go-flags"
+	"net"
+	"os"
+	"strings"
+	"sync"
 )
 
 var opts struct {
-        Threads int `short:"t" long:"threads" default:"8" description:"How many threads should be used"`
-        ResolverIP string `short:"r" long:"resolver" description:"IP of the DNS resolver to use for lookups"`
-        Protocol   string `short:"P" long:"protocol" choice:"tcp" choice:"udp" default:"udp" description:"Protocol to use for lookups"`
-        Port       uint16 `short:"p" long:"port" default:"53" description:"Port to bother the specified DNS resolver on"`
-	Domain     bool   `short:"d" long:"domain" description:"Output only domains"`
+	Threads      int    `short:"t" long:"threads" default:"8" description:"How many threads should be used"`
+	ResolverIP   string `short:"r" long:"resolver" description:"IP of the DNS resolver to use for lookups"`
+	ResolverFile string `short:"R" long:"resolvers-file" description:"File containing list of DNS resolvers to use for lookups"`
+	UseDefault   bool   `short:"U" long:"use-default" description:"Use default resolvers for lookups"`
+	Protocol     string `short:"P" long:"protocol" choice:"tcp" choice:"udp" default:"udp" description:"Protocol to use for lookups"`
+	Port         uint16 `short:"p" long:"port" default:"53" description:"Port to bother the specified DNS resolver on"`
+	Domain       bool   `short:"d" long:"domain" description:"Output only domains"`
+	Help         bool   `short:"h" long:"help" description:"Show help message"`
+}
+
+var defaultResolvers = []string{
+	"1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4", "9.9.9.9", "149.112.112.112",
+	"208.67.222.222", "208.67.220.220", "64.6.64.6", "64.6.65.6", "198.101.242.72",
+	"198.101.242.72", "8.26.56.26", "8.20.247.20", "185.228.168.9", "185.228.169.9",
+	"76.76.19.19", "76.223.122.150", "94.140.14.14", "94.140.15.15",
 }
 
 func main() {
-        _, err := flags.ParseArgs(&opts, os.Args)
-        if err != nil{
-            os.Exit(1)
-        }
+	parser := flags.NewParser(&opts, flags.Default)
+	_, err := parser.Parse()
 
-        // default of 8 threads
-        numWorkers := opts.Threads
+	if err != nil {
+		os.Exit(1)
+	}
 
-        work := make(chan string)
-        go func() {
-            s := bufio.NewScanner(os.Stdin)
-            for s.Scan() {
-                work <- s.Text()
-            }
-            close(work)
-        }()
+	if opts.Help {
+		parser.WriteHelp(os.Stdout)
+		os.Exit(0)
+	}
 
-        wg := &sync.WaitGroup{}
+	var resolvers []string
+	if opts.ResolverFile != "" {
+		file, err := os.Open(opts.ResolverFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to open resolvers file: %v\n", err)
+			os.Exit(1)
+		}
+		defer file.Close()
 
-        for i := 0; i < numWorkers; i++ {
-            wg.Add(1)
-            go doWork(work, wg)
-        }
-        wg.Wait()
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			resolvers = append(resolvers, scanner.Text())
+		}
+
+		if err := scanner.Err(); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to read resolvers file: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	if opts.ResolverIP != "" {
+		resolvers = append(resolvers, opts.ResolverIP)
+	}
+
+	if opts.UseDefault {
+		resolvers = append(resolvers, defaultResolvers...)
+	}
+
+	numWorkers := opts.Threads
+
+	work := make(chan string)
+	go func() {
+		s := bufio.NewScanner(os.Stdin)
+		for s.Scan() {
+			work <- s.Text()
+		}
+		close(work)
+	}()
+
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go doWork(work, wg, resolvers)
+	}
+	wg.Wait()
 }
 
-func doWork(work chan string, wg *sync.WaitGroup) {
-    defer wg.Done()
-    var r *net.Resolver
+func doWork(work chan string, wg *sync.WaitGroup, resolvers []string) {
+	defer wg.Done()
 
-    if opts.ResolverIP != "" {
-            r = &net.Resolver{
-                    PreferGo: true,
-                    Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-                            d := net.Dialer{}
-                            return d.DialContext(ctx, opts.Protocol, fmt.Sprintf("%s:%d", opts.ResolverIP, opts.Port))
-                    },
-            }
-    }
+	for ip := range work {
+		resolved := false
 
-    for ip := range work {
-        addr, err := r.LookupAddr(context.Background(), ip)
-        if err != nil {
-                continue
-        }
+		for _, resolverIP := range resolvers {
+			r := &net.Resolver{
+				PreferGo: true,
+				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+					d := net.Dialer{}
+					return d.DialContext(ctx, opts.Protocol, fmt.Sprintf("%s:%d", resolverIP, opts.Port))
+				},
+			}
 
-        for _, a := range addr {
-		if opts.Domain {
-			fmt.Println(strings.TrimRight(a, "."))
-		} else {
-                	fmt.Println(ip, "\t",a)
+			addr, err := r.LookupAddr(context.Background(), ip)
+			if err == nil {
+				for _, a := range addr {
+					if opts.Domain {
+						fmt.Println(strings.TrimRight(a, "."))
+					} else {
+						fmt.Println(ip, "\t", a)
+					}
+				}
+				resolved = true
+				break
+			}
 		}
-        }
-    }
+
+		if !resolved {
+			// Uncomment this line if you want to see unresolved IPs
+			// fmt.Fprintf(os.Stderr, "Failed to resolve IP: %s\n", ip)
+		}
+	}
 }


### PR DESCRIPTION
### New Flags
-rA, --use-default: 
When specified, this flag tells the program to use a predefined list of default DNS resolvers for lookups. This is useful for ensuring consistent DNS resolution across various environments, especially if no custom resolvers are provided.

-R, --resolvers-file: 
This flag allows you to specify a file containing a list of custom DNS resolvers. Each line in the file should contain a single resolver IP address. If both -R and -r are provided, the resolver specified by -r is added to the list of resolvers from the file.